### PR TITLE
fix: allow multiple vscode instance

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -18,7 +18,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/meaningful-ooo/devcontainer-features/fish": {},
         "ghcr.io/guiyomh/features/vim": {},
         "ghcr.io/guiyomh/features/just": {}


### PR DESCRIPTION

Update the docker-in-docker feature to use a unique name for the volume?  If not, there’s two docker instances trying to hit the same volume.

see [slack](https://github-partners.slack.com/archives/C0431R35H37/p1669762738616239?thread_ts=1669718385.710359&cid=C0431R35H37), [github issue](https://github.com/microsoft/vscode-remote-release/issues/7605)